### PR TITLE
Add link to Mastodon

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,6 @@ The main repositories here are a Ruby profiler I wrote called [rbspy](https://gi
 Some other places you can find my work on the internet:
 
 * blog: https://jvns.ca
+* mastodon: https://mastodon.social/@b0rk@jvns.ca
 * twitter: https://twitter.com/b0rk
 * zines: https://wizardzines.com


### PR DESCRIPTION
Hi :wave:

just read through your "2023 in review" blog post. So much good stuff, thank you. :clap: 
It led me to explore your GitHub as well and I noticed this README is missing your Mastodon account which you mentioned that you're currently using more.

(apologies for unsolicited PR in case this is not useful)